### PR TITLE
1.2.21

### DIFF
--- a/DCManagement/DCManagement.psd1
+++ b/DCManagement/DCManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'DCManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.2.18'
+	ModuleVersion = '1.2.21'
 	
 	# ID used to uniquely identify this module
 	GUID = '998b2262-9b38-4b54-8ce6-493a00d70b03'
@@ -26,7 +26,7 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules = @(
-		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.4.150' }
+		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.6.198' }
 		
 		# Additional Dependencies, cannot declare due to bug in dependency handling in PS5.1
 		# @{ ModuleName = 'ResolveString'; ModuleVersion = '1.0.0' }

--- a/DCManagement/changelog.md
+++ b/DCManagement/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: Shares - Added capability to specify which server to process through `-TargetServer` parameter.
+- Upd: AccessRules - Added capability to specify which server to process through `-TargetServer` parameter.
+
 ## 1.2.18 (2020-10-11)
 
 - Upd: Removed most dependencies due to bug in PS5.1. Dependencies in ADMF itself are now expected to provide the necessary tools / modules.

--- a/DCManagement/changelog.md
+++ b/DCManagement/changelog.md
@@ -1,9 +1,10 @@
 ﻿# Changelog
 
-## ???
+## 1.2.21 (2021-04-23)
 
 - Upd: Shares - Added capability to specify which server to process through `-TargetServer` parameter.
 - Upd: AccessRules - Added capability to specify which server to process through `-TargetServer` parameter.
+- Fix: Test-DCAccessRule - errors when path not found: Cannot bind null to InputObject
 
 ## 1.2.18 (2020-10-11)
 

--- a/DCManagement/functions/AccessRules/Invoke-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Invoke-DCAccessRule.ps1
@@ -48,6 +48,9 @@
 		
 		[PSCredential]
 		$Credential,
+
+        [string[]]
+        $TargetServer,
 		
 		[switch]
 		$EnableException
@@ -56,6 +59,9 @@
 	begin
 	{
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+        if (-not $Server -and $TargetServer) {
+            $parameters.Server = $TargetServer | Select-Object -First 1
+        }
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
@@ -173,6 +179,7 @@
 	}
 	process
 	{
+		if ($TargetServer) { $parameters.TargetServer = $TargetServer }
 		if (-not $InputObject) { $InputObject = Test-DCAccessRule @parameters }
 		
 		foreach ($testItem in ($InputObject | Sort-Object Type -Descending)) # Delete before Add

--- a/DCManagement/functions/AccessRules/Invoke-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Invoke-DCAccessRule.ps1
@@ -19,6 +19,11 @@
 	
 	.PARAMETER Credential
 		The credentials to use for this operation.
+
+    .PARAMETER TargetServer
+        The specific server(s) to process.
+        If specified, only listed domain controllers will be affected.
+        Specify the full FQDN of the server.
 	
 	.PARAMETER EnableException
 		This parameters disables user-friendly warnings and enables the throwing of exceptions.

--- a/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
@@ -32,6 +32,9 @@
 		
 		[PSCredential]
 		$Credential,
+
+        [string[]]
+        $TargetServer,
 		
 		[switch]
 		$EnableException
@@ -40,6 +43,9 @@
 	begin
 	{
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+        if (-not $Server -and $TargetServer) {
+            $parameters.Server = $TargetServer | Select-Object -First 1
+        }
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
@@ -225,6 +231,7 @@
 	{
 		foreach ($domainController in $domainControllers)
 		{
+            if ($TargetServer -and $domainController.Name -notin $TargetServer) { continue }
 			$results = @{
 				ObjectType = 'FSAccessRule'
 				Server	   = $domainController.Name

--- a/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
@@ -256,7 +256,7 @@
 				{
 					foreach ($entry in $path.Group)
 					{
-						New-TestResult @results -Type NoPath -Configuration $entry -Identity $path.Name -Changed (New-Change -RuleObject $desiredRule.AccessRule)
+						New-TestResult @results -Type NoPath -Configuration $entry -Identity $path.Name -Changed (New-Change -RuleObject $entry.AccessRule)
 					}
 					Stop-PSFFunction -String 'Test-DCAccessRule.Path.ExistsNot' -StringValues $domainController.Name, $path.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name
 				}

--- a/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
@@ -14,6 +14,11 @@
 	
 	.PARAMETER Credential
 		The credentials to use for this operation.
+
+    .PARAMETER TargetServer
+        The specific server(s) to process.
+        If specified, only listed domain controllers will be affected.
+        Specify the full FQDN of the server.
 	
 	.PARAMETER EnableException
 		This parameters disables user-friendly warnings and enables the throwing of exceptions.

--- a/DCManagement/functions/shares/Invoke-DCShare.ps1
+++ b/DCManagement/functions/shares/Invoke-DCShare.ps1
@@ -17,6 +17,11 @@
 	
 	.PARAMETER Credential
 		The credentials to use for this operation.
+
+    .PARAMETER TargetServer
+        The specific server(s) to process.
+        If specified, only listed domain controllers will be affected.
+        Specify the full FQDN of the server.
 	
 	.PARAMETER EnableException
 		This parameters disables user-friendly warnings and enables the throwing of exceptions.
@@ -40,12 +45,12 @@
 		
 		[PSFComputer]
 		$Server,
-
-        [string[]]
-        $TargetServer,
 		
 		[PSCredential]
 		$Credential,
+
+        [string[]]
+        $TargetServer,
 		
 		[switch]
 		$EnableException

--- a/DCManagement/functions/shares/Invoke-DCShare.ps1
+++ b/DCManagement/functions/shares/Invoke-DCShare.ps1
@@ -40,6 +40,9 @@
 		
 		[PSFComputer]
 		$Server,
+
+        [string[]]
+        $TargetServer,
 		
 		[PSCredential]
 		$Credential,
@@ -51,6 +54,9 @@
 	begin
 	{
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+        if (-not $Server -and $TargetServer) {
+            $parameters.Server = $TargetServer | Select-Object -First 1
+        }
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
@@ -63,6 +69,7 @@
 	}
 	process
 	{
+        if ($TargetServer) { $parameters.TargetServer = $TargetServer }
 		if (-not $InputObject) { $InputObject = Test-DCShare @parameters }
 		
 		foreach ($testItem in $InputObject)

--- a/DCManagement/functions/shares/Test-DCShare.ps1
+++ b/DCManagement/functions/shares/Test-DCShare.ps1
@@ -13,6 +13,11 @@
 	
 	.PARAMETER Credential
 		The credentials to use for this operation.
+
+    .PARAMETER TargetServer
+        The specific server(s) to process.
+        If specified, only listed domain controllers will be affected.
+        Specify the full FQDN of the server.
 	
 	.PARAMETER EnableException
 		This parameters disables user-friendly warnings and enables the throwing of exceptions.

--- a/DCManagement/functions/shares/Test-DCShare.ps1
+++ b/DCManagement/functions/shares/Test-DCShare.ps1
@@ -30,6 +30,9 @@
 		
 		[PSCredential]
 		$Credential,
+
+        [string[]]
+        $TargetServer,
 		
 		[switch]
 		$EnableException
@@ -38,6 +41,9 @@
 	begin
 	{
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+        if (-not $Server -and $TargetServer) {
+            $parameters.Server = $TargetServer | Select-Object -First 1
+        }
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
@@ -219,6 +225,7 @@
 	{
 		foreach ($domainController in $domainControllers)
 		{
+            if ($TargetServer -and $domainController.Name -notin $TargetServer) { continue }
 			$results = @{
 				ObjectType = 'Share'
 				Server = $domainController.Name

--- a/DCManagement/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/DCManagement/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -12,7 +12,7 @@ if ($SkipTest) { return }
 $global:__pester_data.ScriptAnalyzer = New-Object System.Collections.ArrayList
 
 Describe 'Invoking PSScriptAnalyzer against commandbase' {
-	$commandFiles = Get-ChildItem -Path $CommandPath -Recurse | Where-Object Name -like "*.ps1"
+	$commandFiles = foreach ($path in $CommandPath) { Get-ChildItem -Path $path -Recurse | Where-Object Name -like "*.ps1" }
 	$scriptAnalyzerRules = Get-ScriptAnalyzerRule
 	
 	foreach ($file in $commandFiles)


### PR DESCRIPTION
- Upd: Shares - Added capability to specify which server to process through `-TargetServer` parameter.
- Upd: AccessRules - Added capability to specify which server to process through `-TargetServer` parameter.
- Fix: Test-DCAccessRule - errors when path not found: Cannot bind null to InputObject