### PR TITLE
1.2.25

### DIFF
--- a/DCManagement/DCManagement.psd1
+++ b/DCManagement/DCManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'DCManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.2.21'
+	ModuleVersion = '1.2.25'
 	
 	# ID used to uniquely identify this module
 	GUID = '998b2262-9b38-4b54-8ce6-493a00d70b03'

--- a/DCManagement/changelog.md
+++ b/DCManagement/changelog.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: Test-DCShare - added message tag DCTarget to allow message level modifiers to raise per-server processing messages.
+- Upd: Test-DCAccessRule - added message tag DCTarget to allow message level modifiers to raise per-server processing messages.
+- Fix: Test-DCAccessRule - prompts for confirm on ToString when running in high confirm preference
+
 ## 1.2.21 (2021-04-23)
 
 - Upd: Shares - Added capability to specify which server to process through `-TargetServer` parameter.

--- a/DCManagement/changelog.md
+++ b/DCManagement/changelog.md
@@ -1,9 +1,10 @@
 ﻿# Changelog
 
-## ???
+## 1.2.25 (2021-07-13)
 
 - Upd: Test-DCShare - added message tag DCTarget to allow message level modifiers to raise per-server processing messages.
 - Upd: Test-DCAccessRule - added message tag DCTarget to allow message level modifiers to raise per-server processing messages.
+- Upd: Test-DCAccessRule - added equivalent access detection. Will no longer report about inequal access rules, so long as they result in the same effective permissions.
 - Fix: Test-DCAccessRule - prompts for confirm on ToString when running in high confirm preference
 
 ## 1.2.21 (2021-04-23)

--- a/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
@@ -207,6 +207,7 @@
         }
 
         function Get-EffectiveFlags {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
             [CmdletBinding()]
             param (
                 $AccessRules

--- a/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
@@ -1,6 +1,5 @@
-﻿function Test-DCAccessRule
-{
-<#
+﻿function Test-DCAccessRule {
+    <#
 	.SYNOPSIS
 		Tests all DCs, whether their NTFS filesystem Access Rules are configured as designed.
 	
@@ -29,296 +28,327 @@
 	
 		Tests, whether the filesystem Access Rules on all DCs of the corp.contoso.com domain are configured as designed.
 #>
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
-	[CmdletBinding()]
-	param (
-		[PSFComputer]
-		$Server,
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
+    [CmdletBinding()]
+    param (
+        [PSFComputer]
+        $Server,
 		
-		[PSCredential]
-		$Credential,
+        [PSCredential]
+        $Credential,
 
         [string[]]
         $TargetServer,
 		
-		[switch]
-		$EnableException
-	)
+        [switch]
+        $EnableException
+    )
 	
-	begin
-	{
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+    begin {
+        $parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
         if (-not $Server -and $TargetServer) {
             $parameters.Server = $TargetServer | Select-Object -First 1
         }
-		$parameters['Debug'] = $false
-		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
-		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
-		Assert-Configuration -Type fileSystemAccessRules -Cmdlet $PSCmdlet
-		Set-DCDomainContext @parameters
+        $parameters['Debug'] = $false
+        Assert-ADConnection @parameters -Cmdlet $PSCmdlet
+        Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
+        Assert-Configuration -Type fileSystemAccessRules -Cmdlet $PSCmdlet
+        Set-DCDomainContext @parameters
 		
-		$domainControllers = Get-DomainController @parameters
-		$psCred = $PSBoundParameters | ConvertTo-PSFHashtable -Include Credential
+        $domainControllers = Get-DomainController @parameters
+        $psCred = $PSBoundParameters | ConvertTo-PSFHashtable -Include Credential
 		
-		#region Utility Functions
-		function ConvertFrom-AccessRuleDefinition
-		{
-			[CmdletBinding()]
-			param (
-				[Parameter(ValueFromPipeline = $true)]
-				$InputObject,
+        #region Utility Functions
+        function ConvertFrom-AccessRuleDefinition {
+            [CmdletBinding()]
+            param (
+                [Parameter(ValueFromPipeline = $true)]
+                $InputObject,
 				
-				[hashtable]
-				$Parameters
-			)
+                [hashtable]
+                $Parameters
+            )
 			
-			process
-			{
-				$resolvedPath = Resolve-String -Text $InputObject.Path -ArgumentList $Parameters
+            process {
+                $resolvedPath = Resolve-String -Text $InputObject.Path -ArgumentList $Parameters
 				
-				if ($InputObject.Empty)
-				{
-					[PSCustomObject]@{
-						Path		  = $resolvedPath
-						Identity	  = $null
-						Principal	  = $null
-						AccessRule    = $null
-						Configuration = $InputObject
-						IdentityError = $false
-						ServerRole    = $InputObject.ServerRole
-						AccessMode    = 'Constrained'
-						Empty		  = $true
-					}
-					return
-				}
+                if ($InputObject.Empty) {
+                    [PSCustomObject]@{
+                        Path          = $resolvedPath
+                        Identity      = $null
+                        Principal     = $null
+                        AccessRule    = $null
+                        Configuration = $InputObject
+                        IdentityError = $false
+                        ServerRole    = $InputObject.ServerRole
+                        AccessMode    = 'Constrained'
+                        Empty         = $true
+                    }
+                    return
+                }
 				
-				$resolvedIdentity = Resolve-String -Text $InputObject.Identity -ArgumentList $Parameters
-				$identityError = $false
-				try { $resolvedPrincipal = Resolve-Principal @Parameters -Name $resolvedIdentity -OutputType SID -ErrorAction Stop }
-				catch
-				{
-					$identityError = $true
-					$resolvedPrincipal = [System.Security.Principal.NTAccount]$resolvedIdentity
-				}
+                $resolvedIdentity = Resolve-String -Text $InputObject.Identity -ArgumentList $Parameters
+                $identityError = $false
+                try { $resolvedPrincipal = Resolve-Principal @Parameters -Name $resolvedIdentity -OutputType SID -ErrorAction Stop }
+                catch {
+                    $identityError = $true
+                    $resolvedPrincipal = [System.Security.Principal.NTAccount]$resolvedIdentity
+                }
 				
-				$rule = [System.Security.AccessControl.FileSystemAccessRule]::new($resolvedPrincipal, $InputObject.Rights, $InputObject.Inheritance, $InputObject.Propagation, $InputObject.Type)
-				Add-Member -InputObject $rule -MemberType NoteProperty -Name DisplayName -Value $resolvedIdentity
+                $rule = [System.Security.AccessControl.FileSystemAccessRule]::new($resolvedPrincipal, $InputObject.Rights, $InputObject.Inheritance, $InputObject.Propagation, $InputObject.Type)
+                Add-Member -InputObject $rule -MemberType NoteProperty -Name DisplayName -Value $resolvedIdentity
 				
-				[PSCustomObject]@{
-					Path		  = $resolvedPath
-					Identity	  = $resolvedIdentity
-					Principal	  = $resolvedPrincipal
-					AccessRule    = $rule
-					Configuration = $InputObject
-					IdentityError = $identityError
-					ServerRole    = $InputObject.ServerRole
-					AccessMode    = $InputObject.AccessMode
-					Empty		  = $false
-				}
-			}
-		}
+                [PSCustomObject]@{
+                    Path          = $resolvedPath
+                    Identity      = $resolvedIdentity
+                    Principal     = $resolvedPrincipal
+                    AccessRule    = $rule
+                    Configuration = $InputObject
+                    IdentityError = $identityError
+                    ServerRole    = $InputObject.ServerRole
+                    AccessMode    = $InputObject.AccessMode
+                    Empty         = $false
+                }
+            }
+        }
 		
-		function Get-RemoteAccessRule
-		{
-			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
-			[CmdletBinding()]
-			param (
-				$Session,
+        function Get-RemoteAccessRule {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
+            [CmdletBinding()]
+            param (
+                $Session,
 				
-				[string]
-				$Path
-			)
+                [string]
+                $Path
+            )
 			
-			$rules = Invoke-Command -Session $Session -ScriptBlock {
-				$acl = Get-Acl -Path $using:path
-				foreach ($rule in $acl.Access)
-				{
-					if ($rule.IsInherited) { continue }
-					[PSCustomObject]@{
-						PSTypeName = 'Remote.FileSystemAccessRule'
-						DisplayName = $rule.IdentityReference.ToString()
-						FileSystemRights = $rule.FileSystemRights
-						FileSystemRightsNumeric = [int]$rule.FileSystemRights
-						AccessControlType = $rule.AccessControlType
-						IdentityReference = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
-						InheritanceFlags = $rule.InheritanceFlags
-						PropagationFlags = $rule.PropagationFlags
-						OriginalRights = $rule.FileSystemRights
-					}
-				}
-			}
-			# The default object had display issues when displayed in the "Change" property
-			foreach ($rule in $rules)
-			{
-				$rule.FileSystemRights = Convert-AccessRight -Right $rule.FileSystemRightsNumeric
-				$rule
-			}
-		}
+            $rules = Invoke-Command -Session $Session -ScriptBlock {
+                $acl = Get-Acl -Path $using:path
+                foreach ($rule in $acl.Access) {
+                    if ($rule.IsInherited) { continue }
+                    [PSCustomObject]@{
+                        PSTypeName              = 'Remote.FileSystemAccessRule'
+                        DisplayName             = $rule.IdentityReference.ToString()
+                        FileSystemRights        = $rule.FileSystemRights
+                        FileSystemRightsNumeric = [int]$rule.FileSystemRights
+                        AccessControlType       = $rule.AccessControlType
+                        IdentityReference       = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+                        InheritanceFlags        = $rule.InheritanceFlags
+                        PropagationFlags        = $rule.PropagationFlags
+                        OriginalRights          = $rule.FileSystemRights
+                    }
+                }
+            }
+            # The default object had display issues when displayed in the "Change" property
+            foreach ($rule in $rules) {
+                $rule.FileSystemRights = Convert-AccessRight -Right $rule.FileSystemRightsNumeric
+                $rule
+            }
+        }
 		
-		function New-Change
-		{
-			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
-			[CmdletBinding()]
-			param (
-				$RuleObject
-			)
+        function New-Change {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+            [CmdletBinding()]
+            param (
+                $RuleObject
+            )
 			
-			Add-Member -InputObject $RuleObject -MemberType ScriptMethod -Name ToString -Force -Value {
-				if ($this.DisplayName) { return $this.DisplayName }
+            Add-Member -InputObject $RuleObject -MemberType ScriptMethod -Name ToString -Force -Value {
+                if ($this.DisplayName) { return $this.DisplayName }
 				
-				return $this.IdentityReference
-			} -PassThru
-		}
+                return $this.IdentityReference
+            } -PassThru
+        }
 		
-		function Test-AccessRule
-		{
-			[CmdletBinding()]
-			param (
-				$RuleObject,
+        function Test-AccessRule {
+            [CmdletBinding()]
+            param (
+                $RuleObject,
 				
-				$Reference
-			)
+                $Reference,
+
+                $AllRules
+            )
 			
-			foreach ($entry in $Reference)
-			{
-				if ($entry.FileSystemRights -ne $RuleObject.FileSystemRights) { continue }
-				if ($entry.AccessControlType -ne $RuleObject.AccessControlType) { continue }
-				if ($entry.IdentityReference.ToString() -ne $RuleObject.IdentityReference.ToString()) { continue }
-				if ($entry.InheritanceFlags -ne $RuleObject.InheritanceFlags) { continue }
-				if ($entry.PropagationFlags -ne $RuleObject.PropagationFlags) { continue }
+            foreach ($entry in $Reference) {
+                if ($entry.FileSystemRights -ne $RuleObject.FileSystemRights) { continue }
+                if ($entry.AccessControlType -ne $RuleObject.AccessControlType) { continue }
+                if ($entry.IdentityReference.ToString() -ne $RuleObject.IdentityReference.ToString()) { continue }
+                if ($entry.InheritanceFlags -ne $RuleObject.InheritanceFlags) { continue }
+                if ($entry.PropagationFlags -ne $RuleObject.PropagationFlags) { continue }
 				
-				return $true
-			}
-			return $false
-		}
+                return $true
+            }
+
+            $rulesAffected = $AllRules | Where-Object {
+                "$($_.IdentityReference)" -eq "$($RuleObject.IdentityReference)" -and
+                $_.FileSystemRights -eq $RuleObject.FileSystemRights -and
+                $_.AccessControlType -eq $RuleObject.AccessControlType
+            }
+            $referenceAffected = $Reference | Where-Object {
+                "$($_.IdentityReference)" -eq "$($RuleObject.IdentityReference)" -and
+                $_.FileSystemRights -eq $RuleObject.FileSystemRights -and
+                $_.AccessControlType -eq $RuleObject.AccessControlType
+            }
+
+            if (-not $referenceAffected) { return $false }
+            if ((@($rulesAffected).Count + @($referenceAffected).Count) -le 2) { return $false }
+
+            $rulesFlags = Get-EffectiveFlags -AccessRules $rulesAffected
+            $referenceFlags = Get-EffectiveFlags -AccessRules $referenceAffected
+            if (
+                $rulesFlags.InheritanceFlags -eq $referenceFlags.InheritanceFlags -and
+                $rulesFlags.PropagationFlags -eq $referenceFlags.PropagationFlags
+            ) {
+                return $true
+            }
+
+            return $false
+        }
+
+        function Get-EffectiveFlags {
+            [CmdletBinding()]
+            param (
+                $AccessRules
+            )
+
+            $affectsSelf = $false
+            $affectsChildFiles = $false
+            $affectsChildFolders = $false
+
+            foreach ($rule in $AccessRules) {
+                if ($rule.PropagationFlags -ne 'InheritOnly') {
+                    $affectsSelf = $true
+                }
+                if ($rule.PropagationFlags -ne 'NoPropagateInherit') {
+                    if ($rule.InheritanceFlags -band [System.Security.AccessControl.InheritanceFlags]::ContainerInherit) {
+                        $affectsChildFolders = $true
+                    }
+                    if ($rule.InheritanceFlags -band [System.Security.AccessControl.InheritanceFlags]::ObjectInherit) {
+                        $affectsChildFiles = $true
+                    }
+                }
+            }
+
+            [PSCustomObject]@{
+                # ContainerInherit = 1; ObjectInherit = 2
+                InheritanceFlags = [System.Security.AccessControl.InheritanceFlags](1 * $affectsChildFolders + 2 * $affectsChildFiles)
+                # None = 0; InheritOnly = 2 | Flag only set when NOT affecting self
+                PropagationFlags = [System.Security.AccessControl.PropagationFlags](2 * (-not $affectsSelf))
+            }
+        }
 		
-		function Convert-AccessRight
-		{
-			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
-			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "")]
-			[CmdletBinding()]
-			param (
-				[int]
-				$Right
-			)
-			$bytes = [System.BitConverter]::GetBytes($Right)
-			$uint = [System.BitConverter]::ToUInt32($bytes, 0)
+        function Convert-AccessRight {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "")]
+            [CmdletBinding()]
+            param (
+                [int]
+                $Right
+            )
+            $bytes = [System.BitConverter]::GetBytes($Right)
+            $uint = [System.BitConverter]::ToUInt32($bytes, 0)
 			
-			$definitiveRight = [DCManagement.FileSystemPermission]$uint
+            $definitiveRight = [DCManagement.FileSystemPermission]$uint
 			
-			# https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights
-			# https://docs.microsoft.com/en-us/windows/win32/secauthz/standard-access-rights
-			$genericRightsMap = @{
-				All = [DCManagement.FileSystemPermission]::FullControl
-				Execute = ([DCManagement.FileSystemPermission]'ExecuteFile, ReadAttributes, ReadPermissions, Synchronize')
-				Read = ([DCManagement.FileSystemPermission]'ReadAttributes, ReadData, ReadExtendedAttributes, ReadPermissions, Synchronize')
-				Write = ([DCManagement.FileSystemPermission]'AppendData, WriteAttributes, WriteData, WriteExtendedAttributes, ReadPermissions, Synchronize')
-			}
+            # https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights
+            # https://docs.microsoft.com/en-us/windows/win32/secauthz/standard-access-rights
+            $genericRightsMap = @{
+                All     = [DCManagement.FileSystemPermission]::FullControl
+                Execute = ([DCManagement.FileSystemPermission]'ExecuteFile, ReadAttributes, ReadPermissions, Synchronize')
+                Read    = ([DCManagement.FileSystemPermission]'ReadAttributes, ReadData, ReadExtendedAttributes, ReadPermissions, Synchronize')
+                Write   = ([DCManagement.FileSystemPermission]'AppendData, WriteAttributes, WriteData, WriteExtendedAttributes, ReadPermissions, Synchronize')
+            }
 			
-			if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericAll) { return [System.Security.AccessControl.FileSystemRights]::FullControl }
-			if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericExecute)
-			{
-				$definitiveRight = $definitiveRight -bxor [DCManagement.FileSystemPermission]::GenericExecute -bor $genericRightsMap.Execute
-			}
-			if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericRead)
-			{
-				$definitiveRight = $definitiveRight -bxor [DCManagement.FileSystemPermission]::GenericRead -bor $genericRightsMap.Read
-			}
-			if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericWrite)
-			{
-				$definitiveRight = $definitiveRight -bxor [DCManagement.FileSystemPermission]::GenericWrite -bor $genericRightsMap.Write
-			}
-			[System.Security.AccessControl.FileSystemRights]$definitiveRight.Value__
-		}
-		#endregion Utility Functions
-	}
-	process
-	{
-		foreach ($domainController in $domainControllers)
-		{
+            if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericAll) { return [System.Security.AccessControl.FileSystemRights]::FullControl }
+            if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericExecute) {
+                $definitiveRight = $definitiveRight -bxor [DCManagement.FileSystemPermission]::GenericExecute -bor $genericRightsMap.Execute
+            }
+            if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericRead) {
+                $definitiveRight = $definitiveRight -bxor [DCManagement.FileSystemPermission]::GenericRead -bor $genericRightsMap.Read
+            }
+            if ($definitiveRight -band [DCManagement.FileSystemPermission]::GenericWrite) {
+                $definitiveRight = $definitiveRight -bxor [DCManagement.FileSystemPermission]::GenericWrite -bor $genericRightsMap.Write
+            }
+            [System.Security.AccessControl.FileSystemRights]$definitiveRight.Value__
+        }
+        #endregion Utility Functions
+    }
+    process {
+        foreach ($domainController in $domainControllers) {
             if ($TargetServer -and $domainController.Name -notin $TargetServer) { continue }
-			$results = @{
-				ObjectType = 'FSAccessRule'
-				Server	   = $domainController.Name
-			}
+            $results = @{
+                ObjectType = 'FSAccessRule'
+                Server     = $domainController.Name
+            }
 			
-			Write-PSFMessage -String 'Test-DCAccessRule.Processing' -StringValues $domainController.Name -Target $domainController.Name -Tag DCTarget
-			try { $psSession = New-PSSession -ComputerName $domainController.Name @psCred -ErrorAction Stop }
-			catch { Stop-PSFFunction -String 'Test-DCAccessRule.PSSession.Failed' -StringValues $domainController.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name -ErrorRecord $_ }
-			$accessConfigurations = Get-DCAccessRule | Where-Object {
-				$_.ServerRole -eq 'ALL' -or
-				($_.ServerRole -eq 'FSMO' -and $domainController.IsFSMO) -or
-				($_.ServerRole -eq 'PDC' -and $domainController.IsPDCEmulator)
-			} | ConvertFrom-AccessRuleDefinition -Parameters $parameters
+            Write-PSFMessage -String 'Test-DCAccessRule.Processing' -StringValues $domainController.Name -Target $domainController.Name -Tag DCTarget
+            try { $psSession = New-PSSession -ComputerName $domainController.Name @psCred -ErrorAction Stop }
+            catch { Stop-PSFFunction -String 'Test-DCAccessRule.PSSession.Failed' -StringValues $domainController.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name -ErrorRecord $_ }
+            $accessConfigurations = Get-DCAccessRule | Where-Object {
+                $_.ServerRole -eq 'ALL' -or
+                ($_.ServerRole -eq 'FSMO' -and $domainController.IsFSMO) -or
+                ($_.ServerRole -eq 'PDC' -and $domainController.IsPDCEmulator)
+            } | ConvertFrom-AccessRuleDefinition -Parameters $parameters
 			
-			$groupedByPath = $accessConfigurations | Group-Object -Property Path
-			foreach ($path in $groupedByPath)
-			{
-				Write-PSFMessage -String 'Test-DCAccessRule.Processing.Path' -StringValues $domainController.Name, $path.Name -Target $domainController.Name
+            $groupedByPath = $accessConfigurations | Group-Object -Property Path
+            foreach ($path in $groupedByPath) {
+                Write-PSFMessage -String 'Test-DCAccessRule.Processing.Path' -StringValues $domainController.Name, $path.Name -Target $domainController.Name
 				
-				$pathExists = Invoke-Command -Session $psSession -ScriptBlock { Test-Path -Path $using:path.Name }
-				if (-not $pathExists)
-				{
-					foreach ($entry in $path.Group)
-					{
-						New-TestResult @results -Type NoPath -Configuration $entry -Identity $path.Name -Changed (New-Change -RuleObject $entry.AccessRule)
-					}
-					Stop-PSFFunction -String 'Test-DCAccessRule.Path.ExistsNot' -StringValues $domainController.Name, $path.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name
-				}
+                $pathExists = Invoke-Command -Session $psSession -ScriptBlock { Test-Path -Path $using:path.Name }
+                if (-not $pathExists) {
+                    foreach ($entry in $path.Group) {
+                        New-TestResult @results -Type NoPath -Configuration $entry -Identity $path.Name -Changed (New-Change -RuleObject $entry.AccessRule)
+                    }
+                    Stop-PSFFunction -String 'Test-DCAccessRule.Path.ExistsNot' -StringValues $domainController.Name, $path.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name
+                }
 				
-				$existingRules = Get-RemoteAccessRule -Session $psSession -Path $path.Name
+                $existingRules = Get-RemoteAccessRule -Session $psSession -Path $path.Name
 				
-				#region Empty Mode: No explicit ACE should exist
-				if ($path.Group | Where-Object Empty)
-				{
+                #region Empty Mode: No explicit ACE should exist
+                if ($path.Group | Where-Object Empty) {
 					
-					foreach ($rule in $existingRules)
-					{
-						New-TestResult @results -Type Remove -Configuration $path.Group -ADObject $existingRules -Identity $path.Name -Changed (New-Change -RuleObject $rule)
-					}
-					continue
-				}
-				#endregion Empty Mode: No explicit ACE should exist
+                    foreach ($rule in $existingRules) {
+                        New-TestResult @results -Type Remove -Configuration $path.Group -ADObject $existingRules -Identity $path.Name -Changed (New-Change -RuleObject $rule)
+                    }
+                    continue
+                }
+                #endregion Empty Mode: No explicit ACE should exist
 				
-				$effectiveMode = 'Additive'
-				if ($path.Group | Where-Object AccessMode -EQ 'Defined') { $effectiveMode = 'Defined' }
-				if ($path.Group | Where-Object AccessMode -EQ 'Constrained') { $effectiveMode = 'Constrained' }
+                $effectiveMode = 'Additive'
+                if ($path.Group | Where-Object AccessMode -EQ 'Defined') { $effectiveMode = 'Defined' }
+                if ($path.Group | Where-Object AccessMode -EQ 'Constrained') { $effectiveMode = 'Constrained' }
 				
-				if ($path.Group | Where-Object IdentityError)
-				{
-					# Interrupt if Constrained and resolution error
-					if ($effectiveMode -eq 'Constrained')
-					{
-						$errorCfg = $path.Group | Where-Object IdentityError
-						Stop-PSFFunction -String 'Test-DCAccessRule.Identity.Error' -StringValues $domainController.Name, $path.Name, ($errorCfg.Identity -join ",") -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name
-					}
-					else
-					{
-						Write-PSFMessage -Level Warning -String 'Test-DCAccessRule.Identity.Error' -StringValues $domainController.Name, $path.Name, ($errorCfg.Identity -join ",")
-					}
-				}
+                if ($path.Group | Where-Object IdentityError) {
+                    # Interrupt if Constrained and resolution error
+                    if ($effectiveMode -eq 'Constrained') {
+                        $errorCfg = $path.Group | Where-Object IdentityError
+                        Stop-PSFFunction -String 'Test-DCAccessRule.Identity.Error' -StringValues $domainController.Name, $path.Name, ($errorCfg.Identity -join ",") -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name
+                    }
+                    else {
+                        Write-PSFMessage -Level Warning -String 'Test-DCAccessRule.Identity.Error' -StringValues $domainController.Name, $path.Name, ($errorCfg.Identity -join ",")
+                    }
+                }
 				
-				$effectiveDesiredState = $path.Group | Where-Object IdentityError -NE $true
+                $effectiveDesiredState = $path.Group | Where-Object IdentityError -NE $true
 				
-				#region Compare desired state with existing state
-				foreach ($desiredRule in $effectiveDesiredState)
-				{
-					if (Test-AccessRule -RuleObject $desiredRule.AccessRule -Reference $existingRules) { continue }
-					New-TestResult @results -Type Add -Configuration $desiredRule -ADObject $existingRules -Identity $path.Name -Changed (New-Change -RuleObject $desiredRule.AccessRule)
-				}
+                #region Compare desired state with existing state
+                foreach ($desiredRule in $effectiveDesiredState) {
+                    if (Test-AccessRule -RuleObject $desiredRule.AccessRule -Reference $existingRules -AllRules $effectiveDesiredState.AccessRule) { continue }
+                    New-TestResult @results -Type Add -Configuration $desiredRule -ADObject $existingRules -Identity $path.Name -Changed (New-Change -RuleObject $desiredRule.AccessRule)
+                }
 				
-				if ($effectiveMode -eq 'Additive') { continue }
+                if ($effectiveMode -eq 'Additive') { continue }
 				
-				foreach ($existingRule in $existingRules)
-				{
-					if ($effectiveMode -eq 'Defined' -and "$($existingRule.IdentityReference.ToString())" -notin ($effectiveDesiredState.AccessRule.IdentityReference | ForEach-Object ToString -WhatIf:$false -Confirm:$false)) { continue }
-					if (Test-AccessRule -RuleObject $existingRule -Reference $effectiveDesiredState.AccessRule) { continue }
-					New-TestResult @results -Type Remove -Configuration $effectiveDesiredState -ADObject $existingRule -Identity $path.Name -Changed (New-Change -RuleObject $existingRule)
-				}
-				#endregion Compare desired state with existing state
-			}
+                foreach ($existingRule in $existingRules) {
+                    if ($effectiveMode -eq 'Defined' -and "$($existingRule.IdentityReference.ToString())" -notin ($effectiveDesiredState.AccessRule.IdentityReference | ForEach-Object ToString -WhatIf:$false -Confirm:$false)) { continue }
+                    if (Test-AccessRule -RuleObject $existingRule -Reference $effectiveDesiredState.AccessRule -AllRules $existingRules) { continue }
+                    New-TestResult @results -Type Remove -Configuration $effectiveDesiredState -ADObject $existingRule -Identity $path.Name -Changed (New-Change -RuleObject $existingRule)
+                }
+                #endregion Compare desired state with existing state
+            }
 			
-			Remove-PSSession -Session $psSession -ErrorAction Ignore -Confirm:$false
-		}
-	}
+            Remove-PSSession -Session $psSession -ErrorAction Ignore -Confirm:$false
+        }
+    }
 }

--- a/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
+++ b/DCManagement/functions/AccessRules/Test-DCAccessRule.ps1
@@ -242,7 +242,7 @@
 				Server	   = $domainController.Name
 			}
 			
-			Write-PSFMessage -String 'Test-DCAccessRule.Processing' -StringValues $domainController.Name -Target $domainController.Name
+			Write-PSFMessage -String 'Test-DCAccessRule.Processing' -StringValues $domainController.Name -Target $domainController.Name -Tag DCTarget
 			try { $psSession = New-PSSession -ComputerName $domainController.Name @psCred -ErrorAction Stop }
 			catch { Stop-PSFFunction -String 'Test-DCAccessRule.PSSession.Failed' -StringValues $domainController.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name -ErrorRecord $_ }
 			$accessConfigurations = Get-DCAccessRule | Where-Object {
@@ -311,7 +311,7 @@
 				
 				foreach ($existingRule in $existingRules)
 				{
-					if ($effectiveMode -eq 'Defined' -and "$($existingRule.IdentityReference.ToString())" -notin ($effectiveDesiredState.AccessRule.IdentityReference | ForEach-Object ToString)) { continue }
+					if ($effectiveMode -eq 'Defined' -and "$($existingRule.IdentityReference.ToString())" -notin ($effectiveDesiredState.AccessRule.IdentityReference | ForEach-Object ToString -WhatIf:$false -Confirm:$false)) { continue }
 					if (Test-AccessRule -RuleObject $existingRule -Reference $effectiveDesiredState.AccessRule) { continue }
 					New-TestResult @results -Type Remove -Configuration $effectiveDesiredState -ADObject $existingRule -Identity $path.Name -Changed (New-Change -RuleObject $existingRule)
 				}

--- a/DCManagement/functions/shares/Test-DCShare.ps1
+++ b/DCManagement/functions/shares/Test-DCShare.ps1
@@ -236,7 +236,7 @@
 				Server = $domainController.Name
 			}
 			
-			Write-PSFMessage -String 'Test-DCShare.Processing' -StringValues $domainController.Name
+			Write-PSFMessage -String 'Test-DCShare.Processing' -StringValues $domainController.Name -Tag DCTarget
 			try { $cimSession = New-CimSession -ComputerName $domainController.Name @cimCred -ErrorAction Stop }
 			catch { Stop-PSFFunction -String 'Test-DCShare.CimSession.Failed' -StringValues $domainController.Name -EnableException $EnableException -Cmdlet $PSCmdlet -Continue -Target $domainController.Name -ErrorRecord $_ }
 			$shareConfigurations = Get-DCShare | Where-Object {


### PR DESCRIPTION
- Upd: Test-DCShare - added message tag DCTarget to allow message level modifiers to raise per-server processing messages.
- Upd: Test-DCAccessRule - added message tag DCTarget to allow message level modifiers to raise per-server processing messages.
- Upd: Test-DCAccessRule - added equivalent access detection. Will no longer report about inequal access rules, so long as they result in the same effective permissions.
- Fix: Test-DCAccessRule - prompts for confirm on ToString when running in high confirm preference